### PR TITLE
상세 페이지 구현

### DIFF
--- a/be/market/build.gradle
+++ b/be/market/build.gradle
@@ -52,6 +52,8 @@ dependencies {
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
+    // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     annotationProcessor 'org.projectlombok:lombok'
 

--- a/be/market/src/main/java/com/carrot/market/global/cache/CacheNames.java
+++ b/be/market/src/main/java/com/carrot/market/global/cache/CacheNames.java
@@ -1,0 +1,16 @@
+package com.carrot.market.global.cache;
+
+import lombok.Getter;
+
+@Getter
+public class CacheNames {
+	public static final String PRODUCT_CACHE = "productViewCnt";
+
+	public static String createViewCntCacheKey(Long id) {
+		return createCacheKey(PRODUCT_CACHE, id);
+	}
+
+	public static String createCacheKey(String cacheType, Long id) {
+		return cacheType + "::" + id;
+	}
+}

--- a/be/market/src/main/java/com/carrot/market/global/cache/CacheNames.java
+++ b/be/market/src/main/java/com/carrot/market/global/cache/CacheNames.java
@@ -6,6 +6,10 @@ import lombok.Getter;
 public class CacheNames {
 	public static final String PRODUCT_CACHE = "productViewCnt";
 
+	public static String getProductCachePattern() {
+		return PRODUCT_CACHE + "*";
+	}
+
 	public static String createViewCntCacheKey(Long id) {
 		return createCacheKey(PRODUCT_CACHE, id);
 	}

--- a/be/market/src/main/java/com/carrot/market/global/config/RedisConfig.java
+++ b/be/market/src/main/java/com/carrot/market/global/config/RedisConfig.java
@@ -8,9 +8,6 @@ import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 
-import lombok.extern.slf4j.Slf4j;
-
-@Slf4j
 @Configuration
 public class RedisConfig {
 
@@ -23,25 +20,16 @@ public class RedisConfig {
 	// 커넥션 설정
 	@Bean
 	public RedisConnectionFactory redisConnectionFactory() {
-		log.info(host);
 		RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
 		redisStandaloneConfiguration.setHostName(host);
 		redisStandaloneConfiguration.setPort(port);
-		//		redisStandaloneConfiguration.setPassword(password);
+
 		return new LettuceConnectionFactory(redisStandaloneConfiguration);
 	}
 
 	@Bean
 	public RedisTemplate<?, ?> redisTemplate() {
-
-		// redisTemplate 를 받아와서 set, get, delete 를 사용
 		RedisTemplate<byte[], byte[]> redisTemplate = new RedisTemplate<>();
-		/*
-		 * setKeySerializer, setValueSerializer 설정
-		 * redis-cli 을 통해 직접 데이터를 조회 시 알아볼 수 없는 형태로 출력되는 것을 방지
-		 */
-		//        redisTemplate.setKeySerializer(new StringRedisSerializer());
-		//        redisTemplate.setValueSerializer(new StringRedisSerializer());
 		redisTemplate.setConnectionFactory(redisConnectionFactory());
 
 		return redisTemplate;

--- a/be/market/src/main/java/com/carrot/market/global/config/RedisConfig.java
+++ b/be/market/src/main/java/com/carrot/market/global/config/RedisConfig.java
@@ -1,0 +1,50 @@
+package com.carrot.market.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Configuration
+public class RedisConfig {
+
+	@Value("${spring.data.redis.host}")
+	private String host;
+
+	@Value("${spring.data.redis.port}")
+	private int port;
+
+	// 커넥션 설정
+	@Bean
+	public RedisConnectionFactory redisConnectionFactory() {
+		log.info(host);
+		RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
+		redisStandaloneConfiguration.setHostName(host);
+		redisStandaloneConfiguration.setPort(port);
+		//		redisStandaloneConfiguration.setPassword(password);
+		return new LettuceConnectionFactory(redisStandaloneConfiguration);
+	}
+
+	@Bean
+	public RedisTemplate<?, ?> redisTemplate() {
+
+		// redisTemplate 를 받아와서 set, get, delete 를 사용
+		RedisTemplate<byte[], byte[]> redisTemplate = new RedisTemplate<>();
+		/*
+		 * setKeySerializer, setValueSerializer 설정
+		 * redis-cli 을 통해 직접 데이터를 조회 시 알아볼 수 없는 형태로 출력되는 것을 방지
+		 */
+		//        redisTemplate.setKeySerializer(new StringRedisSerializer());
+		//        redisTemplate.setValueSerializer(new StringRedisSerializer());
+		redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+		return redisTemplate;
+	}
+
+}

--- a/be/market/src/main/java/com/carrot/market/global/config/SchedulingConfig.java
+++ b/be/market/src/main/java/com/carrot/market/global/config/SchedulingConfig.java
@@ -1,0 +1,13 @@
+package com.carrot.market.global.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+@ConditionalOnProperty(
+	value = "app.scheduling.enable", havingValue = "true", matchIfMissing = true
+)
+public class SchedulingConfig {
+}

--- a/be/market/src/main/java/com/carrot/market/global/exception/domain/ProductException.java
+++ b/be/market/src/main/java/com/carrot/market/global/exception/domain/ProductException.java
@@ -1,0 +1,15 @@
+package com.carrot.market.global.exception.domain;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ProductException implements CustomException {
+	NOT_FOUND_ID(HttpStatus.BAD_REQUEST, "존재하지 않은 상품입니다.");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+}

--- a/be/market/src/main/java/com/carrot/market/global/filter/FilterConfig.java
+++ b/be/market/src/main/java/com/carrot/market/global/filter/FilterConfig.java
@@ -16,6 +16,11 @@ public class FilterConfig {
 	private final JwtProvider jwtProvider;
 
 	@Bean
+	JwtAuthorizationFilter filter(ObjectMapper objectMapper) {
+		return new JwtAuthorizationFilter(objectMapper, jwtProvider);
+	}
+
+	@Bean
 	public FilterRegistrationBean<Filter> jwtAuthorizationFilter(ObjectMapper mapper) {
 		FilterRegistrationBean<Filter> filterRegistrationBean = new
 			FilterRegistrationBean<>();

--- a/be/market/src/main/java/com/carrot/market/global/filter/FilterConfig.java
+++ b/be/market/src/main/java/com/carrot/market/global/filter/FilterConfig.java
@@ -21,10 +21,10 @@ public class FilterConfig {
 	}
 
 	@Bean
-	public FilterRegistrationBean<Filter> jwtAuthorizationFilter(ObjectMapper mapper) {
+	public FilterRegistrationBean<Filter> jwtAuthorizationFilter(JwtAuthorizationFilter jwtAuthorizationFilter) {
 		FilterRegistrationBean<Filter> filterRegistrationBean = new
 			FilterRegistrationBean<>();
-		filterRegistrationBean.setFilter(new JwtAuthorizationFilter(mapper, jwtProvider));
+		filterRegistrationBean.setFilter(jwtAuthorizationFilter);
 		filterRegistrationBean.setOrder(1);
 		return filterRegistrationBean;
 	}

--- a/be/market/src/main/java/com/carrot/market/member/infrastructure/WishListRepository.java
+++ b/be/market/src/main/java/com/carrot/market/member/infrastructure/WishListRepository.java
@@ -1,10 +1,15 @@
 package com.carrot.market.member.infrastructure;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.carrot.market.member.domain.WishList;
 
 @Repository
 public interface WishListRepository extends JpaRepository<WishList, Long> {
+	@Query("select count(wl.id) > 0 from WishList as wl where wl.member.id = :member_id and wl.product.id = :product_id")
+	Boolean existsMemberLikeProduct(@Param("member_id") Long memberId, @Param("product_id") Long productId);
+
 }

--- a/be/market/src/main/java/com/carrot/market/member/infrastructure/WishListRepository.java
+++ b/be/market/src/main/java/com/carrot/market/member/infrastructure/WishListRepository.java
@@ -1,7 +1,6 @@
 package com.carrot.market.member.infrastructure;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
@@ -9,7 +8,8 @@ import com.carrot.market.member.domain.WishList;
 
 @Repository
 public interface WishListRepository extends JpaRepository<WishList, Long> {
-	@Query("select count(wl.id) > 0 from WishList as wl where wl.member.id = :member_id and wl.product.id = :product_id")
-	Boolean existsMemberLikeProduct(@Param("member_id") Long memberId, @Param("product_id") Long productId);
+	// @Query("select count(wl.id) > 0 from WishList as wl where wl.member.id = :member_id and wl.product.id = :product_id")
+	Boolean existsWishListByMemberIdAndProductId(@Param("member_id") Long memberId,
+		@Param("product_id") Long productId);
 
 }

--- a/be/market/src/main/java/com/carrot/market/member/presentation/annotation/Login.java
+++ b/be/market/src/main/java/com/carrot/market/member/presentation/annotation/Login.java
@@ -1,0 +1,11 @@
+package com.carrot.market.member.presentation.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Login {
+}

--- a/be/market/src/main/java/com/carrot/market/member/resolver/MemberArgumentResolver.java
+++ b/be/market/src/main/java/com/carrot/market/member/resolver/MemberArgumentResolver.java
@@ -1,0 +1,32 @@
+package com.carrot.market.member.resolver;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import com.carrot.market.member.presentation.annotation.Login;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+@Component
+public class MemberArgumentResolver implements HandlerMethodArgumentResolver {
+	private final String MEMBER_ID = "memberId";
+
+	@Override
+	public boolean supportsParameter(MethodParameter parameter) {
+		boolean hasLoginAnnotation = parameter.hasParameterAnnotation(Login.class);
+		boolean hasUserType = Long.class.isAssignableFrom(parameter.getParameterType());
+
+		return hasLoginAnnotation && hasUserType;
+	}
+
+	@Override
+	public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+		NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+		HttpServletRequest request = (HttpServletRequest)webRequest.getNativeRequest();
+		return request.getAttribute(MEMBER_ID);
+	}
+}

--- a/be/market/src/main/java/com/carrot/market/product/application/ProductCacheService.java
+++ b/be/market/src/main/java/com/carrot/market/product/application/ProductCacheService.java
@@ -1,0 +1,58 @@
+package com.carrot.market.product.application;
+
+import static com.carrot.market.global.cache.CacheNames.*;
+
+import java.time.Duration;
+import java.util.Objects;
+import java.util.Set;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.carrot.market.product.infrastructure.ProductRepository;
+import com.carrot.market.redis.RedisUtil;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+public class ProductCacheService {
+	private final ProductRepository productRepository;
+	private final RedisUtil redisUtil;
+
+	public void addViewCntToRedis(Long productId) {
+		String viewCntKey = createViewCntCacheKey(productId);
+		if (redisUtil.getData(viewCntKey) != null) {
+			redisUtil.increment(viewCntKey);
+			return;
+		}
+
+		redisUtil.setData(
+			viewCntKey,
+			String.valueOf(productRepository.findViewCount(productId) + 1),
+			Duration.ofSeconds(30)
+		);
+	}
+
+	/**
+	 * 5초 캐시 데이터를 RDB 반영 후 삭제한다
+	 */
+	@Scheduled(cron = "0/5 * * * * ?")
+	@Transactional
+	public void applyViewCountToRDB() {
+		Set<String> viewCntKeys = redisUtil.keys("productViewCnt*");
+		if (Objects.requireNonNull(viewCntKeys).isEmpty())
+			return;
+		for (String viewCntKey : viewCntKeys) {
+			Long boardId = extractBoardIdFromKey(viewCntKey);
+			Long viewCount = Long.parseLong(redisUtil.getData(viewCntKey));
+			productRepository.applyViewCntToRDB(boardId, viewCount);
+			redisUtil.deleteData(viewCntKey);
+		}
+	}
+
+	public static Long extractBoardIdFromKey(String key) {
+		return Long.parseLong(key.split("::")[1]);
+	}
+}

--- a/be/market/src/main/java/com/carrot/market/product/application/ProductCacheService.java
+++ b/be/market/src/main/java/com/carrot/market/product/application/ProductCacheService.java
@@ -41,7 +41,7 @@ public class ProductCacheService {
 	@Scheduled(cron = "0/5 * * * * ?")
 	@Transactional
 	public void applyViewCountToRDB() {
-		Set<String> viewCntKeys = redisUtil.keys("productViewCnt*");
+		Set<String> viewCntKeys = redisUtil.keys(getProductCachePattern());
 		if (Objects.requireNonNull(viewCntKeys).isEmpty())
 			return;
 		for (String viewCntKey : viewCntKeys) {

--- a/be/market/src/main/java/com/carrot/market/product/application/ProductService.java
+++ b/be/market/src/main/java/com/carrot/market/product/application/ProductService.java
@@ -24,6 +24,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Service
 public class ProductService {
+	private final ProductCacheService productCacheService;
 	private final QueryProductRepository queryProductRepository;
 	private final CategoryRepository categoryRepository;
 	private final ProductRepository productRepository;
@@ -69,6 +70,8 @@ public class ProductService {
 	}
 
 	public ProductDetailResponseDto getProduct(Long memberId, Long productId) {
+		productCacheService.addViewCntToRedis(productId);
+
 		ProductSellerDetaillDto productDetailDto = productRepository.findProductDetailbyId(productId);
 		List<String> imageUrls = productImageRepository.findImageUrlsbyPrdcutId(productId);
 
@@ -76,7 +79,7 @@ public class ProductService {
 			return ProductDetailResponseDto.from(imageUrls, productDetailDto, false);
 		}
 
-		Boolean isLiked = wishListRepository.existsMemberLikeProduct(memberId, productId);
+		Boolean isLiked = wishListRepository.existsWishListByMemberIdAndProductId(memberId, productId);
 		return ProductDetailResponseDto.from(imageUrls, productDetailDto, isLiked);
 	}
 }

--- a/be/market/src/main/java/com/carrot/market/product/application/ProductService.java
+++ b/be/market/src/main/java/com/carrot/market/product/application/ProductService.java
@@ -7,9 +7,14 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.carrot.market.member.infrastructure.WishListRepository;
 import com.carrot.market.product.application.dto.response.CategoryDto;
 import com.carrot.market.product.application.dto.response.MainPageServiceDto;
+import com.carrot.market.product.application.dto.response.ProductDetailResponseDto;
+import com.carrot.market.product.application.dto.response.ProductSellerDetaillDto;
 import com.carrot.market.product.infrastructure.CategoryRepository;
+import com.carrot.market.product.infrastructure.ProductImageRepository;
+import com.carrot.market.product.infrastructure.ProductRepository;
 import com.carrot.market.product.infrastructure.QueryProductRepository;
 import com.carrot.market.product.infrastructure.dto.MainPageSliceDto;
 
@@ -21,6 +26,9 @@ import lombok.RequiredArgsConstructor;
 public class ProductService {
 	private final QueryProductRepository queryProductRepository;
 	private final CategoryRepository categoryRepository;
+	private final ProductRepository productRepository;
+	private final ProductImageRepository productImageRepository;
+	private final WishListRepository wishListRepository;
 
 	public MainPageServiceDto getMainPage(Long locationId, Long categoryId, Long next, int size) {
 		Slice<MainPageSliceDto> byLocationIdAndCategoryId = queryProductRepository.findByLocationIdAndCategoryId(
@@ -58,5 +66,12 @@ public class ProductService {
 			.stream()
 			.map(CategoryDto::from)
 			.collect(Collectors.toList());
+	}
+
+	public ProductDetailResponseDto getProduct(Long memberId, Long productId) {
+		ProductSellerDetaillDto productDetailDto = productRepository.findProductDetailbyId(productId);
+		List<String> imageUrls = productImageRepository.findImageUrlsbyPrdcutId(productId);
+		Boolean isLiked = wishListRepository.existsMemberLikeProduct(memberId, productId);
+		return ProductDetailResponseDto.from(imageUrls, productDetailDto, isLiked);
 	}
 }

--- a/be/market/src/main/java/com/carrot/market/product/application/ProductService.java
+++ b/be/market/src/main/java/com/carrot/market/product/application/ProductService.java
@@ -3,6 +3,7 @@ package com.carrot.market.product.application;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -62,6 +63,7 @@ public class ProductService {
 		return nextContentId;
 	}
 
+	@Cacheable("categoriesCache")
 	public List<CategoryDto> getCategories() {
 		return categoryRepository.findAll()
 			.stream()
@@ -75,7 +77,7 @@ public class ProductService {
 		ProductSellerDetaillDto productDetailDto = productRepository.findProductDetailbyId(productId);
 		List<String> imageUrls = productImageRepository.findImageUrlsbyPrdcutId(productId);
 
-		if (memberId.equals(null)) {
+		if (memberId == null) {
 			return ProductDetailResponseDto.from(imageUrls, productDetailDto, false);
 		}
 

--- a/be/market/src/main/java/com/carrot/market/product/application/ProductService.java
+++ b/be/market/src/main/java/com/carrot/market/product/application/ProductService.java
@@ -71,6 +71,11 @@ public class ProductService {
 	public ProductDetailResponseDto getProduct(Long memberId, Long productId) {
 		ProductSellerDetaillDto productDetailDto = productRepository.findProductDetailbyId(productId);
 		List<String> imageUrls = productImageRepository.findImageUrlsbyPrdcutId(productId);
+
+		if (memberId.equals(null)) {
+			return ProductDetailResponseDto.from(imageUrls, productDetailDto, false);
+		}
+
 		Boolean isLiked = wishListRepository.existsMemberLikeProduct(memberId, productId);
 		return ProductDetailResponseDto.from(imageUrls, productDetailDto, isLiked);
 	}

--- a/be/market/src/main/java/com/carrot/market/product/application/dto/response/ProductDetailDto.java
+++ b/be/market/src/main/java/com/carrot/market/product/application/dto/response/ProductDetailDto.java
@@ -1,0 +1,39 @@
+package com.carrot.market.product.application.dto.response;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+
+public record ProductDetailDto(
+	String location,
+	String status,
+	String title,
+	String category,
+	LocalDateTime createdAt,
+	String content,
+	Long chatCount,
+	Long likeCount,
+	Long hits,
+	Long price,
+	Boolean isLiked
+) {
+
+	public static ProductDetailDto from(ProductSellerDetaillDto productDetailDto, Boolean isLiked) {
+		return ProductDetailDto.builder().location(productDetailDto.location)
+			.status(productDetailDto.status.name())
+			.title(productDetailDto.name)
+			.category(productDetailDto.category)
+			.createdAt(productDetailDto.createdAt)
+			.content(productDetailDto.content)
+			.chatCount(productDetailDto.chatCount)
+			.likeCount(productDetailDto.likeCount)
+			.hits(productDetailDto.hits)
+			.price(productDetailDto.price)
+			.isLiked(isLiked)
+			.build();
+	}
+
+	@Builder
+	public ProductDetailDto {
+	}
+}

--- a/be/market/src/main/java/com/carrot/market/product/application/dto/response/ProductDetailResponseDto.java
+++ b/be/market/src/main/java/com/carrot/market/product/application/dto/response/ProductDetailResponseDto.java
@@ -1,0 +1,22 @@
+package com.carrot.market.product.application.dto.response;
+
+import java.util.List;
+
+import lombok.Builder;
+
+public record ProductDetailResponseDto(
+	List<String> imageUrls,
+	SellerDetailDto seller,
+	ProductDetailDto product
+) {
+	public static ProductDetailResponseDto from(List<String> imageUrls, ProductSellerDetaillDto productDetailDto,
+		Boolean isLiked) {
+		SellerDetailDto seller = SellerDetailDto.from(productDetailDto);
+		ProductDetailDto product = ProductDetailDto.from(productDetailDto, isLiked);
+		return ProductDetailResponseDto.builder().imageUrls(imageUrls).seller(seller).product(product).build();
+	}
+
+	@Builder
+	public ProductDetailResponseDto {
+	}
+}

--- a/be/market/src/main/java/com/carrot/market/product/application/dto/response/ProductSellerDetaillDto.java
+++ b/be/market/src/main/java/com/carrot/market/product/application/dto/response/ProductSellerDetaillDto.java
@@ -1,0 +1,44 @@
+package com.carrot.market.product.application.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.carrot.market.product.domain.SellingStatus;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ProductSellerDetaillDto {
+	Long chatCount;
+	Long likeCount;
+	String location;
+	SellingStatus status;
+	String category;
+	LocalDateTime createdAt;
+	String content;
+	Long hits;
+	String name;
+	Long price;
+	Long sellerId;
+	String sellerName;
+
+	public ProductSellerDetaillDto(Long chatCount, Long likeCount, String location,
+		SellingStatus status, String category, LocalDateTime createdAt, String content, Long hits, String name,
+		Long price, Long sellerId, String sellerName) {
+		this.chatCount = chatCount;
+		this.likeCount = likeCount;
+		this.location = location;
+		this.status = status;
+		this.category = category;
+		this.createdAt = createdAt;
+		this.content = content;
+		this.hits = hits;
+		this.name = name;
+		this.price = price;
+		this.sellerId = sellerId;
+		this.sellerName = sellerName;
+	}
+}

--- a/be/market/src/main/java/com/carrot/market/product/application/dto/response/SellerDetailDto.java
+++ b/be/market/src/main/java/com/carrot/market/product/application/dto/response/SellerDetailDto.java
@@ -1,0 +1,10 @@
+package com.carrot.market.product.application.dto.response;
+
+public record SellerDetailDto(
+	Long id,
+	String nickname
+) {
+	public static SellerDetailDto from(ProductSellerDetaillDto productDetailDto) {
+		return new SellerDetailDto(productDetailDto.sellerId, productDetailDto.sellerName);
+	}
+}

--- a/be/market/src/main/java/com/carrot/market/product/domain/Product.java
+++ b/be/market/src/main/java/com/carrot/market/product/domain/Product.java
@@ -65,18 +65,20 @@ public class Product extends BaseEntity {
 	@OneToMany(mappedBy = "product")
 	private List<Chatroom> chatrooms = new ArrayList<>();
 
+	private Long viewCount;
 	@LastModifiedDate
 	private LocalDateTime modifiedAt;
 
 	@Builder
 	public Product(ProductDetails productDetails, SellingStatus status, Category category,
-		Member seller, Location location, LocalDateTime modifiedAt) {
+		Member seller, Location location, LocalDateTime modifiedAt, Long viewCount) {
 		this.productDetails = productDetails;
 		this.status = status;
 		this.category = category;
 		saveSeller(seller);
 		this.location = location;
 		this.modifiedAt = modifiedAt;
+		this.viewCount = viewCount;
 	}
 
 	private void saveSeller(Member seller) {

--- a/be/market/src/main/java/com/carrot/market/product/infrastructure/ProductImageRepository.java
+++ b/be/market/src/main/java/com/carrot/market/product/infrastructure/ProductImageRepository.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.carrot.market.product.domain.ProductImage;
@@ -11,6 +12,6 @@ import com.carrot.market.product.domain.ProductImage;
 @Repository
 public interface ProductImageRepository extends JpaRepository<ProductImage, Long> {
 
-	@Query("select pi.image.imageUrl from ProductImage as pi join pi.image")
-	List<String> findImageUrlsbyPrdcutId(Long productId);
+	@Query("select pi.image.imageUrl from ProductImage as pi join pi.image where pi.product.id = :productId")
+	List<String> findImageUrlsbyPrdcutId(@Param("productId") Long productId);
 }

--- a/be/market/src/main/java/com/carrot/market/product/infrastructure/ProductImageRepository.java
+++ b/be/market/src/main/java/com/carrot/market/product/infrastructure/ProductImageRepository.java
@@ -1,10 +1,16 @@
 package com.carrot.market.product.infrastructure;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import com.carrot.market.product.domain.ProductImage;
 
 @Repository
 public interface ProductImageRepository extends JpaRepository<ProductImage, Long> {
+
+	@Query("select pi.image.imageUrl from ProductImage as pi join pi.image")
+	List<String> findImageUrlsbyPrdcutId(Long productId);
 }

--- a/be/market/src/main/java/com/carrot/market/product/infrastructure/ProductRepository.java
+++ b/be/market/src/main/java/com/carrot/market/product/infrastructure/ProductRepository.java
@@ -1,10 +1,24 @@
 package com.carrot.market.product.infrastructure;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import com.carrot.market.product.application.dto.response.ProductSellerDetaillDto;
 import com.carrot.market.product.domain.Product;
 
 @Repository
 public interface ProductRepository extends JpaRepository<Product, Long> {
+	@Query(value =
+		"select new com.carrot.market.product.application.dto.response.ProductSellerDetaillDto( count(distinct chat) , count(distinct wish) , l.name , p.status , c.name , p.createdAt , p.productDetails.content , p.productDetails.hits , p.productDetails.name , p.productDetails.price , seller.id, seller.nickname) "
+			+ " from Product  p "
+			+ "join Chatroom as chat on chat.product= p "
+			+ "join WishList as wish on wish.product = p "
+			+ "join  p.seller as seller "
+			+ "join  p.location as  l "
+			+ "join  p.category as c "
+			+ "group by p,c,l,seller"
+	)
+	ProductSellerDetaillDto findProductDetailbyId(Long productId);
+
 }

--- a/be/market/src/main/java/com/carrot/market/product/infrastructure/ProductRepository.java
+++ b/be/market/src/main/java/com/carrot/market/product/infrastructure/ProductRepository.java
@@ -1,7 +1,9 @@
 package com.carrot.market.product.infrastructure;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.carrot.market.product.application.dto.response.ProductSellerDetaillDto;
@@ -21,4 +23,10 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
 	)
 	ProductSellerDetaillDto findProductDetailbyId(Long productId);
 
+	@Query("select p.viewCount from Product p where p.id = :id")
+	Long findViewCount(@Param("id") Long id);
+
+	@Modifying(clearAutomatically = true)
+	@Query("update Product p set p.viewCount = :viewCnt where p.id = :id")
+	void applyViewCntToRDB(@Param("id") Long id, @Param("viewCnt") Long viewCnt);
 }

--- a/be/market/src/main/java/com/carrot/market/product/infrastructure/QueryProductRepository.java
+++ b/be/market/src/main/java/com/carrot/market/product/infrastructure/QueryProductRepository.java
@@ -90,14 +90,14 @@ public class QueryProductRepository {
 	}
 
 	private BooleanExpression locationIdEq(Long locationId) {
-		if (locationId.equals(null)) {
+		if (locationId == null) {
 			return product.location.id.eq(BASIC_LOCATION_ID);
 		}
 		return product.location.id.eq(locationId);
 	}
 
 	private BooleanExpression categoryEq(Long categoryId) {
-		if (categoryId.equals(null)) {
+		if (categoryId == null) {
 			return null;
 		}
 		return product.category.id.eq(categoryId);

--- a/be/market/src/main/java/com/carrot/market/product/presentation/ProductController.java
+++ b/be/market/src/main/java/com/carrot/market/product/presentation/ProductController.java
@@ -3,14 +3,17 @@ package com.carrot.market.product.presentation;
 import java.util.List;
 
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.carrot.market.global.presentation.ApiResponse;
+import com.carrot.market.member.presentation.annotation.Login;
 import com.carrot.market.product.application.ProductService;
 import com.carrot.market.product.application.dto.response.CategoryDto;
 import com.carrot.market.product.application.dto.response.MainPageServiceDto;
+import com.carrot.market.product.application.dto.response.ProductDetailResponseDto;
 
 import lombok.RequiredArgsConstructor;
 
@@ -36,4 +39,14 @@ public class ProductController {
 		List<CategoryDto> categories = productService.getCategories();
 		return ApiResponse.success(categories);
 	}
+
+	@GetMapping("/products/{productId}")
+	public ApiResponse<ProductDetailResponseDto> detailProduct(
+		@PathVariable Long productId,
+		@Login Long memberId
+	) {
+		ProductDetailResponseDto productDetailResponseDto = productService.getProduct(memberId, productId);
+		return ApiResponse.success(productDetailResponseDto);
+	}
+
 }

--- a/be/market/src/main/java/com/carrot/market/redis/RedisUtil.java
+++ b/be/market/src/main/java/com/carrot/market/redis/RedisUtil.java
@@ -1,0 +1,46 @@
+package com.carrot.market.redis;
+
+import java.time.Duration;
+import java.util.Set;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class RedisUtil {
+
+	private final StringRedisTemplate stringRedisTemplate;
+
+	public String getData(String key) {
+		ValueOperations<String, String> valueOperations = stringRedisTemplate.opsForValue();
+		return valueOperations.get(key);
+	}
+
+	public void setData(String key, String value, Duration timeout) {
+		ValueOperations<String, String> valueOperations = stringRedisTemplate.opsForValue();
+		valueOperations.set(key, value, timeout);
+	}
+
+	public void setDataExpire(String key, String value) {
+		ValueOperations<String, String> valueOperations = stringRedisTemplate.opsForValue();
+		Duration expireDuration = Duration.ofDays(3);
+		valueOperations.set(key, value, expireDuration);
+	}
+
+	public void deleteData(String key) {
+		stringRedisTemplate.delete(key);
+	}
+
+	public void increment(String key) {
+		ValueOperations<String, String> valueOperations = stringRedisTemplate.opsForValue();
+		valueOperations.increment(key);
+	}
+
+	public Set<String> keys(String pattern) {
+		return stringRedisTemplate.keys(pattern);
+	}
+}

--- a/be/market/src/test/java/com/carrot/market/fixture/FixtureFactory.java
+++ b/be/market/src/test/java/com/carrot/market/fixture/FixtureFactory.java
@@ -21,6 +21,7 @@ public class FixtureFactory {
 			.location(location)
 			.status(status)
 			.productDetails(productDetails)
+			.viewCount(0L)
 			.build();
 	}
 

--- a/be/market/src/test/java/com/carrot/market/member/infrastructure/WishListRepositoryTest.java
+++ b/be/market/src/test/java/com/carrot/market/member/infrastructure/WishListRepositoryTest.java
@@ -40,9 +40,9 @@ class WishListRepositoryTest extends IntegrationTestSupport {
 		WishList wishList = makeWishList(product, june);
 		wishListRepository.save(wishList);
 
-		Boolean isLiked = wishListRepository.existsMemberLikeProduct(june.getId(), product.getId());
+		Boolean isLiked = wishListRepository.existsWishListByMemberIdAndProductId(june.getId(), product.getId());
 		assertThat(isLiked).isTrue();
-		Boolean isLiked2 = wishListRepository.existsMemberLikeProduct(bean.getId(), product.getId());
+		Boolean isLiked2 = wishListRepository.existsWishListByMemberIdAndProductId(bean.getId(), product.getId());
 		assertThat(isLiked2).isFalse();
 	}
 }

--- a/be/market/src/test/java/com/carrot/market/member/infrastructure/WishListRepositoryTest.java
+++ b/be/market/src/test/java/com/carrot/market/member/infrastructure/WishListRepositoryTest.java
@@ -1,0 +1,48 @@
+package com.carrot.market.member.infrastructure;
+
+import static com.carrot.market.fixture.FixtureFactory.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.carrot.market.image.infrastructure.ImageRepository;
+import com.carrot.market.member.domain.Member;
+import com.carrot.market.member.domain.WishList;
+import com.carrot.market.product.domain.Product;
+import com.carrot.market.product.infrastructure.ProductImageRepository;
+import com.carrot.market.product.infrastructure.ProductRepository;
+import com.carrot.market.support.IntegrationTestSupport;
+
+class WishListRepositoryTest extends IntegrationTestSupport {
+	@Autowired
+	ImageRepository imageRepository;
+	@Autowired
+	ProductRepository productRepository;
+	@Autowired
+	ProductImageRepository productImageRepository;
+	@Autowired
+	MemberRepository memberRepository;
+	@Autowired
+	WishListRepository wishListRepository;
+
+	@Test
+	void isMemberLikeProduct() {
+		// given
+		Member june = makeMember("june", "sadfas");
+		Member bean = makeMember("bean", "sadfas");
+		memberRepository.saveAll(List.of(june, bean));
+		Product product = Product.builder().seller(june).build();
+		productRepository.save(product);
+
+		WishList wishList = makeWishList(product, june);
+		wishListRepository.save(wishList);
+
+		Boolean isLiked = wishListRepository.existsMemberLikeProduct(june.getId(), product.getId());
+		assertThat(isLiked).isTrue();
+		Boolean isLiked2 = wishListRepository.existsMemberLikeProduct(bean.getId(), product.getId());
+		assertThat(isLiked2).isFalse();
+	}
+}

--- a/be/market/src/test/java/com/carrot/market/product/application/ProductCacheServiceTest.java
+++ b/be/market/src/test/java/com/carrot/market/product/application/ProductCacheServiceTest.java
@@ -1,0 +1,78 @@
+package com.carrot.market.product.application;
+
+import static com.carrot.market.fixture.FixtureFactory.*;
+import static com.carrot.market.global.cache.CacheNames.*;
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.carrot.market.member.domain.Member;
+import com.carrot.market.member.infrastructure.MemberRepository;
+import com.carrot.market.product.domain.Product;
+import com.carrot.market.product.infrastructure.ProductRepository;
+import com.carrot.market.redis.RedisUtil;
+import com.carrot.market.support.CacheTestSupport;
+
+import jakarta.persistence.EntityManager;
+
+class ProductCacheServiceTest extends CacheTestSupport {
+	@Autowired
+	ProductCacheService productCacheService;
+	@Autowired
+	ProductRepository productRepository;
+	@Autowired
+	MemberRepository memberRepository;
+	@Autowired
+	RedisUtil redisUtil;
+	@Autowired
+	EntityManager entityManager;
+
+	@AfterEach
+	void tearDown() {
+		productRepository.deleteAllInBatch();
+		memberRepository.deleteAllInBatch();
+
+	}
+
+	@Transactional
+	@Test
+	void addViewCntToRedis() {
+		// given
+		Member june = makeMember("june", "www.naver.com");
+		memberRepository.save(june);
+		Product product = Product.builder().seller(june).viewCount(0L).build();
+		productRepository.save(product);
+		Long productId = 1L;
+
+		// when
+		productCacheService.addViewCntToRedis(productId);
+		productCacheService.addViewCntToRedis(productId);
+
+		// then
+		String viewCntCacheKey = createViewCntCacheKey(productId);
+		Long viewCount = Long.parseLong(redisUtil.getData(viewCntCacheKey));
+		assertThat(viewCount).isEqualTo(2L);
+	}
+
+	@Test
+	void applyViewCountToRDB() throws InterruptedException {
+		// given
+		Member june = makeMember("june", "www.naver.com");
+		memberRepository.save(june);
+		Product product = Product.builder().seller(june).viewCount(0L).build();
+		productRepository.save(product);
+		productCacheService.addViewCntToRedis(product.getId());
+		productCacheService.addViewCntToRedis(product.getId());
+
+		// when
+		Thread.sleep(10000L);
+
+		// then
+		Product byId = productRepository.findById(product.getId()).get();
+		assertThat(byId.getViewCount()).isEqualTo(2L);
+	}
+
+}

--- a/be/market/src/test/java/com/carrot/market/product/application/ProductServiceTest.java
+++ b/be/market/src/test/java/com/carrot/market/product/application/ProductServiceTest.java
@@ -23,6 +23,7 @@ import com.carrot.market.member.infrastructure.MemberRepository;
 import com.carrot.market.member.infrastructure.WishListRepository;
 import com.carrot.market.product.application.dto.response.CategoryDto;
 import com.carrot.market.product.application.dto.response.MainPageServiceDto;
+import com.carrot.market.product.application.dto.response.ProductDetailResponseDto;
 import com.carrot.market.product.domain.Category;
 import com.carrot.market.product.domain.Product;
 import com.carrot.market.product.domain.ProductDetails;
@@ -138,6 +139,44 @@ class ProductServiceTest extends IntegrationTestSupport {
 				tuple(category2.getName(), category2.getImageUrl()),
 				tuple(category3.getName(), category3.getImageUrl())
 			);
+	}
+
+	@Test
+	void getPrductDetail() {
+		// given
+		Member june = makeMember("june", "www.codesquad.kr");
+		Member bean = makeMember("bean", "www.codesquad.kr");
+		memberRepository.saveAll(List.of(june, bean));
+
+		Location location = makeLocation("susongdong");
+		locationRepository.save(location);
+
+		Image image = makeImage("www.google.com");
+		imageRepository.save(image);
+
+		Category category = makeCategory("dress", "www.naver.com");
+		categoryRepository.save(category);
+		Product product = makeProductWishListChatRoomProductImage(june, bean, location, image, category);
+		productRepository.save(product);
+		// when
+		ProductDetailResponseDto productDetailResponseDto = productService.getProduct(june.getId(), product.getId());
+		assertAll(
+			() -> assertThat(productDetailResponseDto.imageUrls().get(0)).isEqualTo(image.getImageUrl()),
+			() -> assertThat(productDetailResponseDto.seller().id()).isEqualTo(june.getId()),
+			() -> assertThat(productDetailResponseDto.seller().nickname()).isEqualTo(june.getNickname()),
+			() -> assertThat(productDetailResponseDto.product().location()).isEqualTo(location.getName()),
+			() -> assertThat(productDetailResponseDto.product().status()).isEqualTo(SellingStatus.SELLING.name()),
+			() -> assertThat(productDetailResponseDto.product().title()).isEqualTo("title"),
+			() -> assertThat(productDetailResponseDto.product().category()).isEqualTo(category.getName()),
+			() -> assertThat(productDetailResponseDto.product().createdAt()).isEqualTo(product.getCreatedAt()),
+			() -> assertThat(productDetailResponseDto.product().content()).isEqualTo("content"),
+			() -> assertThat(productDetailResponseDto.product().chatCount()).isEqualTo(2),
+			() -> assertThat(productDetailResponseDto.product().likeCount()).isEqualTo(1),
+			() -> assertThat(productDetailResponseDto.product().price()).isEqualTo(3000L),
+			() -> assertThat(productDetailResponseDto.product().isLiked()).isTrue());
+
+		// then
+
 	}
 
 	private Product makeProductWishListChatRoomProductImage(Member june, Member bean, Location location, Image image,

--- a/be/market/src/test/java/com/carrot/market/product/infrastructure/ProductImageRepositoryTest.java
+++ b/be/market/src/test/java/com/carrot/market/product/infrastructure/ProductImageRepositoryTest.java
@@ -1,0 +1,48 @@
+package com.carrot.market.product.infrastructure;
+
+import static com.carrot.market.fixture.FixtureFactory.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.carrot.market.image.domain.Image;
+import com.carrot.market.image.infrastructure.ImageRepository;
+import com.carrot.market.member.domain.Member;
+import com.carrot.market.member.infrastructure.MemberRepository;
+import com.carrot.market.product.domain.Product;
+import com.carrot.market.product.domain.ProductImage;
+import com.carrot.market.support.IntegrationTestSupport;
+
+class ProductImageRepositoryTest extends IntegrationTestSupport {
+	@Autowired
+	ImageRepository imageRepository;
+	@Autowired
+	ProductRepository productRepository;
+	@Autowired
+	ProductImageRepository productImageRepository;
+	@Autowired
+	MemberRepository memberRepository;
+
+	@Test
+	void findImageUrlsbyPrdcutId() {
+		// given
+		Member june = makeMember("june", "sadfas");
+		memberRepository.save(june);
+		Image image = makeImage("www.google.com");
+		Image image2 = makeImage("www.naver.com");
+		imageRepository.saveAll(List.of(image, image2));
+		Product product = Product.builder().seller(june).build();
+		productRepository.save(product);
+
+		ProductImage productImage = makeProductImage(product, image, true);
+		ProductImage productImage2 = makeProductImage(product, image2, false);
+		productImageRepository.saveAll(List.of(productImage, productImage2));
+
+		List<String> imageUrlsbyPrdcutId = productImageRepository.findImageUrlsbyPrdcutId(product.getId());
+
+		assertThat(imageUrlsbyPrdcutId).hasSize(2).containsExactly("www.google.com", "www.naver.com");
+	}
+}

--- a/be/market/src/test/java/com/carrot/market/product/infrastructure/ProductRepositoryTest.java
+++ b/be/market/src/test/java/com/carrot/market/product/infrastructure/ProductRepositoryTest.java
@@ -1,6 +1,8 @@
 package com.carrot.market.product.infrastructure;
 
 import static com.carrot.market.fixture.FixtureFactory.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.List;
 
@@ -71,7 +73,16 @@ class ProductRepositoryTest extends IntegrationTestSupport {
 		ProductSellerDetaillDto productDetailbyId = productRepository.findProductDetailbyId(product.getId());
 
 		// then
-		System.out.println(productDetailbyId.toString());
+		assertAll(
+			() -> assertThat(productDetailbyId.getCategory()).isEqualTo("dress"),
+			() -> assertThat(productDetailbyId.getChatCount()).isEqualTo(2L),
+			() -> assertThat(productDetailbyId.getContent()).isEqualTo("content"),
+			() -> assertThat(productDetailbyId.getLikeCount()).isEqualTo(1L),
+			() -> assertThat(productDetailbyId.getLocation()).isEqualTo("susongdong"),
+			() -> assertThat(productDetailbyId.getPrice()).isEqualTo(3000L),
+			() -> assertThat(productDetailbyId.getHits()).isEqualTo(3000L),
+			() -> assertThat(productDetailbyId.getName()).isEqualTo("title")
+		);
 	}
 
 	private Product makeProductWishListChatRoomProductImage(Member june, Member bean, Location location, Image image,

--- a/be/market/src/test/java/com/carrot/market/product/infrastructure/ProductRepositoryTest.java
+++ b/be/market/src/test/java/com/carrot/market/product/infrastructure/ProductRepositoryTest.java
@@ -74,14 +74,14 @@ class ProductRepositoryTest extends IntegrationTestSupport {
 
 		// then
 		assertAll(
-			() -> assertThat(productDetailbyId.getCategory()).isEqualTo("dress"),
+			() -> assertThat(productDetailbyId.getCategory()).isEqualTo(product.getCategory().getName()),
 			() -> assertThat(productDetailbyId.getChatCount()).isEqualTo(2L),
-			() -> assertThat(productDetailbyId.getContent()).isEqualTo("content"),
+			() -> assertThat(productDetailbyId.getContent()).isEqualTo(product.getProductDetails().getContent()),
 			() -> assertThat(productDetailbyId.getLikeCount()).isEqualTo(1L),
-			() -> assertThat(productDetailbyId.getLocation()).isEqualTo("susongdong"),
-			() -> assertThat(productDetailbyId.getPrice()).isEqualTo(3000L),
-			() -> assertThat(productDetailbyId.getHits()).isEqualTo(3000L),
-			() -> assertThat(productDetailbyId.getName()).isEqualTo("title")
+			() -> assertThat(productDetailbyId.getLocation()).isEqualTo(product.getLocation().getName()),
+			() -> assertThat(productDetailbyId.getPrice()).isEqualTo(product.getProductDetails().getPrice()),
+			() -> assertThat(productDetailbyId.getHits()).isEqualTo(product.getProductDetails().getHits()),
+			() -> assertThat(productDetailbyId.getName()).isEqualTo(product.getProductDetails().getName())
 		);
 	}
 

--- a/be/market/src/test/java/com/carrot/market/product/infrastructure/ProductRepositoryTest.java
+++ b/be/market/src/test/java/com/carrot/market/product/infrastructure/ProductRepositoryTest.java
@@ -1,0 +1,94 @@
+package com.carrot.market.product.infrastructure;
+
+import static com.carrot.market.fixture.FixtureFactory.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.carrot.market.chatroom.domain.Chatroom;
+import com.carrot.market.chatroom.infrastructure.ChatroomRepository;
+import com.carrot.market.image.domain.Image;
+import com.carrot.market.image.infrastructure.ImageRepository;
+import com.carrot.market.location.domain.Location;
+import com.carrot.market.location.infrastructure.LocationRepository;
+import com.carrot.market.member.domain.Member;
+import com.carrot.market.member.domain.WishList;
+import com.carrot.market.member.infrastructure.MemberRepository;
+import com.carrot.market.member.infrastructure.WishListRepository;
+import com.carrot.market.product.application.dto.response.ProductSellerDetaillDto;
+import com.carrot.market.product.domain.Category;
+import com.carrot.market.product.domain.Product;
+import com.carrot.market.product.domain.ProductDetails;
+import com.carrot.market.product.domain.ProductImage;
+import com.carrot.market.product.domain.SellingStatus;
+import com.carrot.market.support.IntegrationTestSupport;
+
+import jakarta.persistence.EntityManager;
+
+class ProductRepositoryTest extends IntegrationTestSupport {
+	@Autowired
+	ProductRepository productRepository;
+	@Autowired
+	WishListRepository wishListRepository;
+	@Autowired
+	CategoryRepository categoryRepository;
+	@Autowired
+	ProductImageRepository productImageRepository;
+	@Autowired
+	ImageRepository imageRepository;
+	@Autowired
+	LocationRepository locationRepository;
+	@Autowired
+	MemberRepository memberRepository;
+
+	@Autowired
+	QueryProductRepository queryProductRepository;
+	@Autowired
+	ChatroomRepository chatroomRepository;
+	@Autowired
+	EntityManager entityManager;
+
+	@Test
+	void findProductDetailbyId() {
+		// given
+		Member june = makeMember("june", "www.codesquad.kr");
+		Member bean = makeMember("bean", "www.codesquad.kr");
+		memberRepository.saveAll(List.of(june, bean));
+
+		Location location = makeLocation("susongdong");
+		locationRepository.save(location);
+
+		Image image = makeImage("www.google.com");
+		imageRepository.save(image);
+
+		Category category = makeCategory("dress", "www.naver.com");
+		categoryRepository.save(category);
+		Product product = makeProductWishListChatRoomProductImage(june, bean, location, image, category);
+
+		// when
+		ProductSellerDetaillDto productDetailbyId = productRepository.findProductDetailbyId(product.getId());
+
+		// then
+		System.out.println(productDetailbyId.toString());
+	}
+
+	private Product makeProductWishListChatRoomProductImage(Member june, Member bean, Location location, Image image,
+		Category category) {
+		Product product = makeProduct(june, location, category, SellingStatus.SELLING,
+			new ProductDetails("title", 3000L, "content", 3000L));
+		productRepository.save(product);
+
+		WishList wishList = makeWishList(product, june);
+		wishListRepository.save(wishList);
+
+		ProductImage productImage = makeProductImage(product, image, true);
+		productImageRepository.save(productImage);
+
+		Chatroom chatroom = makeChatRoom(product, june);
+		Chatroom chatroom2 = makeChatRoom(product, bean);
+		chatroomRepository.saveAll(List.of(chatroom, chatroom2));
+		return product;
+	}
+}

--- a/be/market/src/test/java/com/carrot/market/product/presentation/ProductControllerTest.java
+++ b/be/market/src/test/java/com/carrot/market/product/presentation/ProductControllerTest.java
@@ -13,6 +13,9 @@ import org.junit.jupiter.api.Test;
 
 import com.carrot.market.product.application.dto.response.CategoryDto;
 import com.carrot.market.product.application.dto.response.MainPageServiceDto;
+import com.carrot.market.product.application.dto.response.ProductDetailDto;
+import com.carrot.market.product.application.dto.response.ProductDetailResponseDto;
+import com.carrot.market.product.application.dto.response.SellerDetailDto;
 import com.carrot.market.product.domain.SellingStatus;
 import com.carrot.market.product.infrastructure.dto.MainPageSliceDto;
 import com.carrot.market.support.ControllerTestSupport;
@@ -69,6 +72,48 @@ class ProductControllerTest extends ControllerTestSupport {
 			.andExpect(jsonPath("$.data.[1].id").value(2L))
 			.andExpect(jsonPath("$.data.[1].name").value("june"))
 			.andExpect(jsonPath("$.data.[1].imageUrl").value("www.google.com"));
-
 	}
+
+	@Test
+	void productDetail() throws Exception {
+		// given
+		SellerDetailDto june = new SellerDetailDto(1L, "June");
+		ProductDetailDto productDetailDto = ProductDetailDto.builder()
+			.location("soosongdong")
+			.status(SellingStatus.SELLING.name())
+			.title("title")
+			.category("category")
+			.content("content")
+			.chatCount(1L)
+			.likeCount(2L)
+			.hits(3L)
+			.price(1000L)
+			.isLiked(false)
+			.build();
+		ProductDetailResponseDto productDetailResponseDto = new ProductDetailResponseDto(List.of("www.google.com"),
+			june, productDetailDto);
+
+		when(productService.getProduct(any(), any())).thenReturn(productDetailResponseDto);
+
+		mockMvc.perform(
+				get("/api/products/1")
+			)
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value("true"))
+			.andExpect(jsonPath("$.data.imageUrls[0]").value("www.google.com"))
+			.andExpect(jsonPath("$.data.seller.id").value(1L))
+			.andExpect(jsonPath("$.data.seller.nickname").value("June"))
+			.andExpect(jsonPath("$.data.product.location").value("soosongdong"))
+			.andExpect(jsonPath("$.data.product.status").value(SellingStatus.SELLING.name()))
+			.andExpect(jsonPath("$.data.product.title").value("title"))
+			.andExpect(jsonPath("$.data.product.category").value("category"))
+			.andExpect(jsonPath("$.data.product.content").value("content"))
+			.andExpect(jsonPath("$.data.product.chatCount").value(1L))
+			.andExpect(jsonPath("$.data.product.likeCount").value(2L))
+			.andExpect(jsonPath("$.data.product.hits").value(3L))
+			.andExpect(jsonPath("$.data.product.price").value(1000L))
+			.andExpect(jsonPath("$.data.product.isLiked").value(false));
+	}
+
 }

--- a/be/market/src/test/java/com/carrot/market/support/CacheTestSupport.java
+++ b/be/market/src/test/java/com/carrot/market/support/CacheTestSupport.java
@@ -3,11 +3,9 @@ package com.carrot.market.support;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.transaction.annotation.Transactional;
 
-@TestPropertySource(properties = "app.scheduling.enable=false")
-@Transactional
+@TestPropertySource(properties = "app.scheduling.enable=true")
 @ActiveProfiles("test")
 @SpringBootTest
-public abstract class IntegrationTestSupport {
+public abstract class CacheTestSupport {
 }


### PR DESCRIPTION
## What is this PR? 👓

- 상품 상세 Api 구현
- 조회수 @Scheduling을 통해 5초에 한 번씩 update
- ## Key changes 🔑

- SQL은 productImageUrl, productDetail, isLiked 총 3번 쿼리를 사용한다.
- jpql query를 통해 상세페이지를 구현
- Login Id가 null이면 isLike filed false로 return한다.
- 상세페이지를 조회하게 되면 redis에 viewCount+1을 한 뒤, Scheduling을 통해 5초에 한 번씩 Update쿼리를 날린다.

## To reviewers 👋
