### PR TITLE
채팅방 목록 가져오기

### DIFF
--- a/be/market/src/main/java/com/carrot/market/chat/application/ChatService.java
+++ b/be/market/src/main/java/com/carrot/market/chat/application/ChatService.java
@@ -11,7 +11,6 @@ import com.carrot.market.chat.domain.Chatting;
 import com.carrot.market.chat.infrastructure.mongo.ChattingRepository;
 import com.carrot.market.chat.presentation.dto.Message;
 import com.carrot.market.global.util.KafkaConstant;
-import com.carrot.market.member.infrastructure.MemberRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -20,7 +19,6 @@ import lombok.RequiredArgsConstructor;
 public class ChatService {
 	private final ChattingRepository chatRepository;
 	private final MessageSender messageSender;
-	private final MemberRepository memberRepository;
 	private final MongoTemplate mongoTemplate;
 
 	@Transactional

--- a/be/market/src/main/java/com/carrot/market/chat/domain/Chatting.java
+++ b/be/market/src/main/java/com/carrot/market/chat/domain/Chatting.java
@@ -2,6 +2,7 @@ package com.carrot.market.chat.domain;
 
 import java.time.LocalDateTime;
 
+import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import com.carrot.market.chat.presentation.dto.Message;
@@ -15,10 +16,12 @@ import lombok.Getter;
 public class Chatting {
 	@Id
 	private String id;
+	@Indexed
 	private Long chatRoomId;
 	private Long senderId;
 	private String content;
 	private LocalDateTime createdAt;
+	@Indexed
 	private int readCount;
 
 	@Builder
@@ -38,4 +41,7 @@ public class Chatting {
 			.build();
 	}
 
+	public void readChatting() {
+		readCount = 0;
+	}
 }

--- a/be/market/src/main/java/com/carrot/market/chat/infrastructure/mongo/ChattingRepository.java
+++ b/be/market/src/main/java/com/carrot/market/chat/infrastructure/mongo/ChattingRepository.java
@@ -1,5 +1,9 @@
 package com.carrot.market.chat.infrastructure.mongo;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.data.mongodb.repository.Aggregation;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 
@@ -7,5 +11,18 @@ import com.carrot.market.chat.domain.Chatting;
 
 @Repository
 public interface ChattingRepository extends MongoRepository<Chatting, String> {
+	@Aggregation(pipeline = {
+		"{ '$match': { 'chatRoomId' : ?0  ,  'createdAt' : { $lt : ?1 } } }",
+		"{ '$sort' : { 'createdAt' : -1 } }",
+		"{ '$limit' : ?2 }"
+	})
+	List<Chatting> findByChatRoomIdWithPageable(Long chatRoomId, LocalDateTime chattingTime, int limit);
+
+	// @Aggregation(pipeline = {
+	// 	"{ '$match': { 'chatRoomId' : ?0 } }",
+	// 	"{ '$sort' : { 'createdAt' : -1 } }",
+	// 	"{ '$limit' : ?1 }"
+	// })
+	// List<Chatting> findByChatRoomIdWithFirstPage(Long chatRoomId, int limit);
 
 }

--- a/be/market/src/main/java/com/carrot/market/chat/infrastructure/mongo/ChattingRepository.java
+++ b/be/market/src/main/java/com/carrot/market/chat/infrastructure/mongo/ChattingRepository.java
@@ -1,9 +1,11 @@
 package com.carrot.market.chat.infrastructure.mongo;
 
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
 
 import com.carrot.market.chat.domain.Chatting;
 
+@Repository
 public interface ChattingRepository extends MongoRepository<Chatting, String> {
 
 }

--- a/be/market/src/main/java/com/carrot/market/chatroom/application/ChatroomService.java
+++ b/be/market/src/main/java/com/carrot/market/chatroom/application/ChatroomService.java
@@ -1,13 +1,28 @@
 package com.carrot.market.chatroom.application;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.AggregationResults;
+import org.springframework.data.mongodb.core.aggregation.GroupOperation;
+import org.springframework.data.mongodb.core.aggregation.MatchOperation;
+import org.springframework.data.mongodb.core.aggregation.SortOperation;
+import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.carrot.market.chatroom.application.dto.response.ChatroomInfo;
+import com.carrot.market.chatroom.application.dto.response.ChattingListResponse;
 import com.carrot.market.chatroom.domain.Chatroom;
 import com.carrot.market.chatroom.domain.ChatroomCounter;
 import com.carrot.market.chatroom.infrastructure.ChatroomRepository;
+import com.carrot.market.chatroom.infrastructure.dto.ChatroomResponse;
 import com.carrot.market.chatroom.infrastructure.redis.ChatroomCounterRepository;
 import com.carrot.market.global.exception.ApiException;
 import com.carrot.market.global.exception.domain.MemberException;
@@ -22,9 +37,19 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Service
 public class ChatroomService {
+	private final String CHAT_ROOM_ID = "chatRoomId";
+	private final String CHAT_READ_COUNT = "readCount";
+	private final String CHAT_CREATED_AT = "createdAt";
+	private final String CHAT_CONTENT = "content";
+	private final String LATEST_CHAT_CONTENT = "latestChatContent";
+	private final String UNREAD_CHAT_COUNT = "unreadChatCount";
+	private final String CHATTING = "chatting";
+	private final Long UNREAD = 1L;
 	private final ChatroomRepository chatroomRepository;
 	private final MemberRepository memberRepository;
 	private final ProductRepository productRepository;
+	private final MongoTemplate mongoTemplate;
+
 	private final ChatroomCounterRepository chatRoomCounterRepository;
 
 	public Long getChatroomId(Long productId, Long purchaserId) {
@@ -40,13 +65,45 @@ public class ChatroomService {
 	@Transactional
 	public Chatroom makeChatroom(Long productId, Long purchaserId) {
 		Product product = findByproductId(productId);
-		Member purchaser = findBymemberId(purchaserId);
+		Member purchaser = findByMemberId(purchaserId);
 
 		Chatroom chatroom = new Chatroom(product, purchaser);
 		return chatroomRepository.save(chatroom);
 	}
 
-	private Member findBymemberId(Long purchaserId) {
+	public List<ChattingListResponse> getChattingList(Long memberId) {
+		List<ChatroomResponse> chattingList = chatroomRepository.getChattingByMemberId(
+			memberId);
+		List<ChatroomInfo> chatDetails = getChatDetails(
+			chattingList.stream().map(ChatroomResponse::getChatroomId).toList());
+
+		Map<Long, ChatroomInfo> chatDetailsMap = chatDetails.stream()
+			.collect(Collectors.toMap(ChatroomInfo::chatRoomId, Function.identity()));
+
+		return chattingList.stream()
+			.map(chatting -> new ChattingListResponse(chatting, chatDetailsMap.get(chatting.getChatroomId())))
+			.collect(Collectors.toList());
+	}
+
+	public List<ChatroomInfo> getChatDetails(List<Long> chatroomIds) {
+		MatchOperation matchStage = Aggregation.match(
+			Criteria.where(CHAT_ROOM_ID).in(chatroomIds).and(CHAT_READ_COUNT).is(UNREAD)
+		);
+
+		SortOperation sortStage = Aggregation.sort(Sort.Direction.DESC, CHAT_CREATED_AT);
+
+		GroupOperation groupStage = Aggregation.group(CHAT_ROOM_ID)
+			.last(CHAT_CONTENT).as(LATEST_CHAT_CONTENT)
+			.last(CHAT_ROOM_ID).as(CHAT_ROOM_ID)
+			.count().as(UNREAD_CHAT_COUNT);
+
+		Aggregation aggregation = Aggregation.newAggregation(matchStage, sortStage, groupStage);
+		AggregationResults<ChatroomInfo> chatting = mongoTemplate.aggregate(aggregation, CHATTING,
+			ChatroomInfo.class);
+		return chatting.getMappedResults();
+	}
+
+	private Member findByMemberId(Long purchaserId) {
 		return memberRepository.findById(purchaserId)
 			.orElseThrow(() -> new ApiException(MemberException.NOT_FOUND_MEMBER));
 	}

--- a/be/market/src/main/java/com/carrot/market/chatroom/application/ChatroomService.java
+++ b/be/market/src/main/java/com/carrot/market/chatroom/application/ChatroomService.java
@@ -95,6 +95,7 @@ public class ChatroomService {
 		GroupOperation groupStage = Aggregation.group(CHAT_ROOM_ID)
 			.last(CHAT_CONTENT).as(LATEST_CHAT_CONTENT)
 			.last(CHAT_ROOM_ID).as(CHAT_ROOM_ID)
+			.last(CHAT_CREATED_AT).as(CHAT_CREATED_AT)
 			.count().as(UNREAD_CHAT_COUNT);
 
 		Aggregation aggregation = Aggregation.newAggregation(matchStage, sortStage, groupStage);

--- a/be/market/src/main/java/com/carrot/market/chatroom/application/dto/response/ChatroomInfo.java
+++ b/be/market/src/main/java/com/carrot/market/chatroom/application/dto/response/ChatroomInfo.java
@@ -1,0 +1,8 @@
+package com.carrot.market.chatroom.application.dto.response;
+
+public record ChatroomInfo(
+	Long chatRoomId,
+	Long unreadChatCount,
+	String latestChatContent
+) {
+}

--- a/be/market/src/main/java/com/carrot/market/chatroom/application/dto/response/ChatroomInfo.java
+++ b/be/market/src/main/java/com/carrot/market/chatroom/application/dto/response/ChatroomInfo.java
@@ -1,8 +1,11 @@
 package com.carrot.market.chatroom.application.dto.response;
 
+import java.time.LocalDateTime;
+
 public record ChatroomInfo(
 	Long chatRoomId,
 	Long unreadChatCount,
-	String latestChatContent
+	String latestChatContent,
+	LocalDateTime createdAt
 ) {
 }

--- a/be/market/src/main/java/com/carrot/market/chatroom/application/dto/response/ChattingListResponse.java
+++ b/be/market/src/main/java/com/carrot/market/chatroom/application/dto/response/ChattingListResponse.java
@@ -2,24 +2,18 @@ package com.carrot.market.chatroom.application.dto.response;
 
 import java.time.LocalDateTime;
 
-import com.carrot.market.chatroom.infrastructure.dto.ChatroomResponse;
+import com.carrot.market.chat.domain.Chatting;
 
+import lombok.Builder;
+
+@Builder
 public record ChattingListResponse(
-	String nickname,
-	String imageUrl,
-	String locationName,
-	String productMainImage,
-	Long unreadChatCount,
-	String latestChatContent,
-	LocalDateTime createdAt
+	String chattingId,
+	String content,
+	LocalDateTime createdAt,
+	Long senderId
 ) {
-	public ChattingListResponse(ChatroomResponse chatroomResponse, ChatroomInfo chatroomInfo) {
-		this(chatroomResponse.getNickname()
-			, chatroomResponse.getImageUrl()
-			, chatroomResponse.getLocationName()
-			, chatroomResponse.getProductMainImage()
-			, chatroomInfo.unreadChatCount()
-			, chatroomInfo.latestChatContent()
-			, chatroomInfo.createdAt());
+	public ChattingListResponse(Chatting chatting) {
+		this(chatting.getId(), chatting.getContent(), chatting.getCreatedAt(), chatting.getSenderId());
 	}
 }

--- a/be/market/src/main/java/com/carrot/market/chatroom/application/dto/response/ChattingListResponse.java
+++ b/be/market/src/main/java/com/carrot/market/chatroom/application/dto/response/ChattingListResponse.java
@@ -1,5 +1,7 @@
 package com.carrot.market.chatroom.application.dto.response;
 
+import java.time.LocalDateTime;
+
 import com.carrot.market.chatroom.infrastructure.dto.ChatroomResponse;
 
 public record ChattingListResponse(
@@ -8,7 +10,8 @@ public record ChattingListResponse(
 	String locationName,
 	String productMainImage,
 	Long unreadChatCount,
-	String latestChatContent
+	String latestChatContent,
+	LocalDateTime createdAt
 ) {
 	public ChattingListResponse(ChatroomResponse chatroomResponse, ChatroomInfo chatroomInfo) {
 		this(chatroomResponse.getNickname()
@@ -16,6 +19,7 @@ public record ChattingListResponse(
 			, chatroomResponse.getLocationName()
 			, chatroomResponse.getProductMainImage()
 			, chatroomInfo.unreadChatCount()
-			, chatroomInfo.latestChatContent());
+			, chatroomInfo.latestChatContent()
+			, chatroomInfo.createdAt());
 	}
 }

--- a/be/market/src/main/java/com/carrot/market/chatroom/application/dto/response/ChattingListResponse.java
+++ b/be/market/src/main/java/com/carrot/market/chatroom/application/dto/response/ChattingListResponse.java
@@ -1,0 +1,21 @@
+package com.carrot.market.chatroom.application.dto.response;
+
+import com.carrot.market.chatroom.infrastructure.dto.ChatroomResponse;
+
+public record ChattingListResponse(
+	String nickname,
+	String imageUrl,
+	String locationName,
+	String productMainImage,
+	Long unreadChatCount,
+	String latestChatContent
+) {
+	public ChattingListResponse(ChatroomResponse chatroomResponse, ChatroomInfo chatroomInfo) {
+		this(chatroomResponse.getNickname()
+			, chatroomResponse.getImageUrl()
+			, chatroomResponse.getLocationName()
+			, chatroomResponse.getProductMainImage()
+			, chatroomInfo.unreadChatCount()
+			, chatroomInfo.latestChatContent());
+	}
+}

--- a/be/market/src/main/java/com/carrot/market/chatroom/application/dto/response/ChattingroomListResponse.java
+++ b/be/market/src/main/java/com/carrot/market/chatroom/application/dto/response/ChattingroomListResponse.java
@@ -1,0 +1,25 @@
+package com.carrot.market.chatroom.application.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.carrot.market.chatroom.infrastructure.dto.ChatroomResponse;
+
+public record ChattingroomListResponse(
+	String nickname,
+	String imageUrl,
+	String locationName,
+	String productMainImage,
+	Long unreadChatCount,
+	String latestChatContent,
+	LocalDateTime createdAt
+) {
+	public ChattingroomListResponse(ChatroomResponse chatroomResponse, ChatroomInfo chatroomInfo) {
+		this(chatroomResponse.getNickname()
+			, chatroomResponse.getImageUrl()
+			, chatroomResponse.getLocationName()
+			, chatroomResponse.getProductMainImage()
+			, chatroomInfo.unreadChatCount()
+			, chatroomInfo.latestChatContent()
+			, chatroomInfo.createdAt());
+	}
+}

--- a/be/market/src/main/java/com/carrot/market/chatroom/infrastructure/ChatroomRepository.java
+++ b/be/market/src/main/java/com/carrot/market/chatroom/infrastructure/ChatroomRepository.java
@@ -1,13 +1,62 @@
 package com.carrot.market.chatroom.infrastructure;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.carrot.market.chatroom.domain.Chatroom;
+import com.carrot.market.chatroom.infrastructure.dto.ChatroomResponse;
 
 @Repository
 public interface ChatroomRepository extends JpaRepository<Chatroom, Long> {
 	Optional<Chatroom> findByProductIdAndPurchaserId(Long productId, Long purchaserId);
+
+	@Query(
+		value =
+			"SELECT\n"
+				+ "    (CASE \n"
+				+ "        WHEN seller.id = :memberId \n"
+				+ "	       THEN purchaser.nickname  \n"
+				+ "        ELSE seller.nickname   \n"
+				+ "    END) as nickName ,\n"
+				+ "    (CASE \n"
+				+ "        WHEN seller.id = :memberId \n"
+				+ "        THEN purchaser.image_url  \n"
+				+ "        ELSE seller.image_url  \n"
+				+ "    END) as imageUrl,\n"
+				+ "    location.name as locationName, \n"
+				+ "    image.image_url as productMainImage, \n"
+				+ "    chatroom.id as chatroomid\n"
+				+ "FROM\n"
+				+ "    chatroom \n"
+				+ "LEFT JOIN\n"
+				+ "    product ON chatroom.product_id = product.id\n"
+				+ "LEFT JOIN\n"
+				+ "    product_image as pi ON chatroom.product_id = pi.product_id AND pi.is_main = 1 \n"
+				+ "LEFT JOIN\n"
+				+ "\timage ON image.id = pi.image_id\n"
+				+ "LEFT JOIN\n"
+				+ "    member as seller ON product.member_id = seller.id \n"
+				+ "LEFT JOIN\n"
+				+ "    member as purchaser ON chatroom.member_id = purchaser.id \n"
+				+ "LEFT JOIN\n"
+				+ "    location ON product.location_id = location.id \n"
+				+ "WHERE\n"
+				+ "    product.member_id = :memberId OR purchaser.id = :memberId \n"
+				+ "GROUP BY\n"
+				+ "    product.member_id,\n"
+				+ "    purchaser.nickname,\n"
+				+ "    purchaser.image_url,\n"
+				+ "    seller.nickname,\n"
+				+ "    seller.image_url,\n"
+				+ "    location.name,\n"
+				+ "    image.image_url,\n"
+				+ "    chatroom.id;\n;", nativeQuery = true
+	)
+	List<ChatroomResponse> getChattingByMemberId(@Param("memberId") Long memberId);
+
 }

--- a/be/market/src/main/java/com/carrot/market/chatroom/infrastructure/dto/ChatroomResponse.java
+++ b/be/market/src/main/java/com/carrot/market/chatroom/infrastructure/dto/ChatroomResponse.java
@@ -1,0 +1,14 @@
+package com.carrot.market.chatroom.infrastructure.dto;
+
+public interface ChatroomResponse {
+	String getNickname();
+
+	String getImageUrl();
+
+	String getLocationName();
+
+	String getProductMainImage();
+
+	Long getChatroomId();
+
+}

--- a/be/market/src/main/java/com/carrot/market/global/exception/domain/ChattingException.java
+++ b/be/market/src/main/java/com/carrot/market/global/exception/domain/ChattingException.java
@@ -1,0 +1,14 @@
+package com.carrot.market.global.exception.domain;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ChattingException implements CustomException {
+	INVALID_CHATTING_ID(HttpStatus.BAD_REQUEST, "존재하지 않은 채팅입니다");
+	private final HttpStatus httpStatus;
+	private final String message;
+}

--- a/be/market/src/test/java/com/carrot/market/chat/infrastructure/mongo/ChattingRepositoryTest.java
+++ b/be/market/src/test/java/com/carrot/market/chat/infrastructure/mongo/ChattingRepositoryTest.java
@@ -1,0 +1,67 @@
+package com.carrot.market.chat.infrastructure.mongo;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.carrot.market.chat.domain.Chatting;
+import com.carrot.market.chatroom.domain.Chatroom;
+import com.carrot.market.chatroom.infrastructure.ChatroomRepository;
+import com.carrot.market.support.IntegrationTestSupport;
+
+class ChattingRepositoryTest extends IntegrationTestSupport {
+	@Autowired
+	ChattingRepository chattingRepository;
+	@Autowired
+	ChatroomRepository chatroomRepository;
+
+	@Test
+	void findByChatRoomIdWithFirstPage() {
+		// given
+		Chatroom chatroom = chatroomRepository.save(Chatroom.builder().product(null).purchaser(null).build());
+		for (int num = 0; num < 10; num++) {
+			Chatting chatting = Chatting.builder()
+				.chatRoomId(chatroom.getId())
+				.content("hello" + num)
+				.senderId(1L)
+				.build();
+			chattingRepository.save(chatting);
+		}
+		// then
+		List<Chatting> byChatRoomIdWithPageable = chattingRepository.findByChatRoomIdWithPageable(chatroom.getId(),
+			LocalDateTime.now(), 5);
+		// when
+		assertThat(byChatRoomIdWithPageable).hasSize(5);
+
+	}
+
+	@Test
+	void findByChatRoomIdWithPageable() {
+		// given
+		Chatroom chatroom = chatroomRepository.save(Chatroom.builder().product(null).purchaser(null).build());
+		for (int num = 0; num < 10; num++) {
+			Chatting chatting = Chatting.builder()
+				.chatRoomId(chatroom.getId())
+				.content("hello" + num)
+				.senderId(1L)
+				.build();
+			chattingRepository.save(chatting);
+		}
+		// then
+		List<Chatting> byChatRoomIdWithPageable = chattingRepository.findByChatRoomIdWithPageable(chatroom.getId(),
+			LocalDateTime.now(), 5);
+		byChatRoomIdWithPageable.forEach(chatting -> System.out.println(chatting.getContent()));
+
+		// when
+		Chatting lastChatting = byChatRoomIdWithPageable.get(byChatRoomIdWithPageable.size() - 1);
+		List<Chatting> byChatRoomIdWithPageable2 = chattingRepository.findByChatRoomIdWithPageable(chatroom.getId(),
+			lastChatting.getCreatedAt(), 3);
+		assertThat(byChatRoomIdWithPageable2).hasSize(3);
+
+	}
+
+}

--- a/be/market/src/test/java/com/carrot/market/chatroom/application/ChatroomServiceTest.java
+++ b/be/market/src/test/java/com/carrot/market/chatroom/application/ChatroomServiceTest.java
@@ -2,7 +2,9 @@ package com.carrot.market.chatroom.application;
 
 import static com.carrot.market.fixture.FixtureFactory.*;
 import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
 
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 import org.junit.jupiter.api.AfterEach;
@@ -208,5 +210,12 @@ class ChatroomServiceTest extends IntegrationTestSupport {
 				"latestChatContent")
 			.contains(tuple("bean", "www.google.com", "susongdong", "www.naver.com", 1L, "hello"),
 				tuple("sully", "www.google.com", "susongdong", "www.naver.com", 2L, "hello3"));
+
+		assertAll(
+			() -> assertThat(chattingList.get(0).createdAt().truncatedTo(ChronoUnit.SECONDS))
+				.isEqualTo(firstChat.getCreatedAt().truncatedTo(ChronoUnit.SECONDS)),
+			() -> assertThat(chattingList.get(1).createdAt().truncatedTo(ChronoUnit.SECONDS))
+				.isEqualTo(thirdChat.getCreatedAt().truncatedTo(ChronoUnit.SECONDS)
+				));
 	}
 }

--- a/be/market/src/test/java/com/carrot/market/chatroom/application/ChatroomServiceTest.java
+++ b/be/market/src/test/java/com/carrot/market/chatroom/application/ChatroomServiceTest.java
@@ -14,7 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import com.carrot.market.chat.domain.Chatting;
 import com.carrot.market.chat.infrastructure.mongo.ChattingRepository;
 import com.carrot.market.chatroom.application.dto.response.ChatroomInfo;
-import com.carrot.market.chatroom.application.dto.response.ChattingListResponse;
+import com.carrot.market.chatroom.application.dto.response.ChattingroomListResponse;
 import com.carrot.market.chatroom.domain.Chatroom;
 import com.carrot.market.chatroom.domain.ChatroomCounter;
 import com.carrot.market.chatroom.infrastructure.ChatroomRepository;
@@ -202,7 +202,7 @@ class ChatroomServiceTest extends IntegrationTestSupport {
 		chattingRepository.saveAll(List.of(firstChat, secondChat, thirdChat));
 
 		// when
-		List<ChattingListResponse> chattingList = chatroomService.getChattingList(seller.getId());
+		List<ChattingroomListResponse> chattingList = chatroomService.getChattingroomList(seller.getId());
 
 		// then
 		assertThat(chattingList).hasSize(2)

--- a/be/market/src/test/java/com/carrot/market/chatroom/infrastructure/QueryChatroomRepositoryTest.java
+++ b/be/market/src/test/java/com/carrot/market/chatroom/infrastructure/QueryChatroomRepositoryTest.java
@@ -1,0 +1,100 @@
+package com.carrot.market.chatroom.infrastructure;
+
+import static com.carrot.market.fixture.FixtureFactory.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.carrot.market.chatroom.domain.Chatroom;
+import com.carrot.market.chatroom.infrastructure.dto.ChatroomResponse;
+import com.carrot.market.image.domain.Image;
+import com.carrot.market.image.infrastructure.ImageRepository;
+import com.carrot.market.location.domain.Location;
+import com.carrot.market.location.infrastructure.LocationRepository;
+import com.carrot.market.member.domain.Member;
+import com.carrot.market.member.infrastructure.MemberRepository;
+import com.carrot.market.member.infrastructure.WishListRepository;
+import com.carrot.market.product.domain.Category;
+import com.carrot.market.product.domain.Product;
+import com.carrot.market.product.domain.ProductDetails;
+import com.carrot.market.product.domain.ProductImage;
+import com.carrot.market.product.domain.SellingStatus;
+import com.carrot.market.product.infrastructure.CategoryRepository;
+import com.carrot.market.product.infrastructure.ProductImageRepository;
+import com.carrot.market.product.infrastructure.ProductRepository;
+import com.carrot.market.product.infrastructure.QueryProductRepository;
+import com.carrot.market.support.IntegrationTestSupport;
+
+import jakarta.persistence.EntityManager;
+
+class QueryChatroomRepositoryTest extends IntegrationTestSupport {
+	@Autowired
+	ProductRepository productRepository;
+	@Autowired
+	WishListRepository wishListRepository;
+	@Autowired
+	CategoryRepository categoryRepository;
+	@Autowired
+	ProductImageRepository productImageRepository;
+	@Autowired
+	ImageRepository imageRepository;
+	@Autowired
+	LocationRepository locationRepository;
+	@Autowired
+	MemberRepository memberRepository;
+
+	@Autowired
+	QueryProductRepository queryProductRepository;
+	@Autowired
+	ChatroomRepository chatroomRepository;
+	@Autowired
+	EntityManager entityManager;
+
+	@Test
+	void getChattingList() {
+		// given
+		Member june = makeMember("june", "www.codesquad.kr");
+		Member bean = makeMember("bean", "www.codesquad.kr");
+		Member sully = makeMember("sully", "www.codesquad.kr");
+		memberRepository.saveAll(List.of(june, bean, sully));
+
+		Location location = makeLocation("susongdong");
+		locationRepository.save(location);
+
+		Image image = makeImage("www.google.com");
+		imageRepository.save(image);
+
+		Category category = makeCategory("dress", "www.naver.com");
+		categoryRepository.save(category);
+		Product product = makeProduct(june, location, category, SellingStatus.SELLING,
+			new ProductDetails("title", 3000L, "content", 3000L));
+		Product product2 = makeProduct(june, location, category, SellingStatus.SELLING,
+			new ProductDetails("title", 3000L, "content", 3000L));
+		productRepository.saveAll(List.of(product, product2));
+
+		ProductImage productImage = makeProductImage(product, image, true);
+		ProductImage productImage2 = makeProductImage(product2, image, true);
+		productImageRepository.saveAll(List.of(productImage, productImage2));
+
+		Chatroom chatroom = makeChatRoom(product, bean);
+		Chatroom chatroom2 = makeChatRoom(product2, sully);
+		chatroomRepository.saveAll(List.of(chatroom, chatroom2));
+		// when
+		List<ChatroomResponse> chattingList = chatroomRepository.getChattingByMemberId(
+			june.getId());
+
+		assertThat(
+			chattingList
+		).hasSize(2)
+			.extracting("nickname", "imageUrl", "locationName", "productMainImage", "chatroomId")
+			.containsExactly(
+				tuple("bean", "www.codesquad.kr", "susongdong", "www.google.com", chatroom.getId()),
+				tuple("sully", "www.codesquad.kr", "susongdong", "www.google.com", chatroom2.getId())
+
+			);
+	}
+
+}


### PR DESCRIPTION
## What is this PR? 👓
채팅방 목록을 불러온다.
당근과 비슷하게 안 읽은 채팅 수, 지역 이름, 상품 대표 이미지, 최신 채팅 내용, 최신 채팅 시간, 채팅 상대방 이름, 채팅 상대방 사진
## Key changes 🔑
mongoTemplate를 활용하여 채팅 정보들을 가져왔습니다.
NativeQueyr를 활용하여 채팅방 , 상품, 지역을 가져왔습니다.
## To reviewers 👋
